### PR TITLE
Use readonly

### DIFF
--- a/src/components/AnalogClock/chronograph.ts
+++ b/src/components/AnalogClock/chronograph.ts
@@ -1,17 +1,17 @@
-import { computed, ComputedRef } from 'vue';
+import { computed, DeepReadonly, Ref } from 'vue';
 import { useLocalStorage } from '../../compositions/local-storage';
 
 const STARTED = 'chronograph.started';
 const DURATION = 'chronograph.duration';
 
 interface Chronograph {
-  duration: ComputedRef<number>;
-  paused: ComputedRef<boolean>;
+  duration: DeepReadonly<Ref<number>>;
+  paused: DeepReadonly<Ref<boolean>>;
   startOrStop: () => void;
   reset: () => void;
 }
 
-export const useChronograph = (quartz: ComputedRef<number>): Chronograph => {
+export const useChronograph = (quartz: Ref<number>): Chronograph => {
   const [rawStarted, setRawStarted] = useLocalStorage(STARTED);
   const [rawStored, setRawStored] = useLocalStorage(DURATION);
 

--- a/src/components/AnalogClock/clock.ts
+++ b/src/components/AnalogClock/clock.ts
@@ -1,7 +1,14 @@
-import { computed, ComputedRef, onBeforeUnmount, onMounted, ref } from 'vue';
+import {
+  DeepReadonly,
+  onBeforeUnmount,
+  onMounted,
+  readonly,
+  Ref,
+  ref,
+} from 'vue';
 
 interface Clock {
-  quartz: ComputedRef<number>;
+  quartz: DeepReadonly<Ref<number>>;
 }
 
 export const useClock = (): Clock => {
@@ -23,5 +30,5 @@ export const useClock = (): Clock => {
     if (frame !== null) cancelAnimationFrame(frame);
   });
 
-  return { quartz: computed(() => quartz.value) };
+  return { quartz: readonly(quartz) };
 };

--- a/src/compositions/local-storage.ts
+++ b/src/compositions/local-storage.ts
@@ -1,4 +1,11 @@
-import { computed, ComputedRef, onBeforeUnmount, onMounted, ref } from 'vue';
+import {
+  DeepReadonly,
+  onBeforeUnmount,
+  onMounted,
+  readonly,
+  Ref,
+  ref,
+} from 'vue';
 
 export type SetValue = (value: string | null) => void;
 
@@ -10,9 +17,8 @@ interface LocalStorageOptions {
 export const useLocalStorage = (
   key: string,
   { window = self, localStorage = self.localStorage }: LocalStorageOptions = {},
-): [ComputedRef<string | null>, SetValue] => {
+): [DeepReadonly<Ref<string | null>>, SetValue] => {
   const refValue = ref<string | null>(null);
-  const computedValue = computed(() => refValue.value);
 
   const setValue = (value: string | null) => {
     if (value !== null) localStorage.setItem(key, value);
@@ -33,5 +39,5 @@ export const useLocalStorage = (
     window.removeEventListener('storage', listener);
   });
 
-  return [computedValue, setValue];
+  return [readonly(refValue), setValue];
 };


### PR DESCRIPTION
This PR modifies the code to not use `computed` unnecessarily, but to use `readonly` instead.