### PR TITLE
Improve nextFrame

### DIFF
--- a/src/helpers/frame.ts
+++ b/src/helpers/frame.ts
@@ -1,23 +1,31 @@
-export class AbortError extends Error {}
+const ABORT_ERROR_NAME = 'AbortError';
 
-export interface Options {
+const error = () => {
+  const error = new Error(
+    'Failed to wait next animation frame: The user aborted a animation frame',
+  );
+  error.name = ABORT_ERROR_NAME;
+  return error;
+};
+
+export interface FrameOptions {
   signal?: AbortSignal;
 }
 
-export const nextFrame = async (options: Options = {}): Promise<number> =>
+export const nextFrame = async (options: FrameOptions = {}): Promise<number> =>
   new Promise<number>((resolve, reject) => {
     const { signal } = options;
-    const abort = () => {
-      cancelAnimationFrame(handle);
-      reject(
-        new AbortError(
-          'Failed to wait next animation frame: The user aborted a request',
-        ),
-      );
-    };
-    const handle = requestAnimationFrame((time) => {
+    if (signal?.aborted) return reject(error());
+
+    const onAnimationFrame = (time: number) => {
+      signal?.removeEventListener('abort', onAbort);
       resolve(time);
-      signal?.removeEventListener('abort', abort);
-    });
-    signal?.addEventListener('abort', abort);
+    };
+    const onAbort = () => {
+      signal?.removeEventListener('abort', onAbort);
+      cancelAnimationFrame(handle);
+      reject(error());
+    };
+    const handle = requestAnimationFrame(onAnimationFrame);
+    signal?.addEventListener('abort', onAbort);
   });


### PR DESCRIPTION
This PR improves `nextFrame()`.

Before:

```ts
const ab = new AbortController();
const { signal } = ab;
await nextFrame({ signal }); // hung up
```

After:

```ts
const ab = new AbortController();
const { signal } = ab;
await nextFrame({ signal }); // rejected
```
